### PR TITLE
Fix bugs in example.py and eventvision.py

### DIFF
--- a/eventvision.py
+++ b/eventvision.py
@@ -267,7 +267,11 @@ def show_em(em_events):
     return
 
 
-def show_td(td_events):
+def show_td(td_events, waitDelay = 1):
+    """Display the spikes as an image for waitDelay milliseconds
+    td_events: Events
+    waitDelay: milliseconds
+    """
     max_x = max(td_events.x)+1
     max_y = max(td_events.y)+1
 
@@ -284,7 +288,7 @@ def show_td(td_events):
         img = 255*td_img
         img = img.astype('uint8')
         cv2.imshow('img',img)
-        cv2.waitKey(1)
+        cv2.waitKey(waitDelay)
         frame_end = frame_end+frame_length
         
     cv2.destroyAllWindows()
@@ -332,11 +336,20 @@ def sort_order(events):
     return eventsOut
 
 def extract_roi(td_events, top_left, size):
-    valid_indices = (td_events.x > top_left[0]) & (td_events.y > top_left[1]) & (td_events.x < (size[0]+top_left[0])) & (td_events.y > (top_left[1]+size[1]))
+    """Extract a region of interest from the Events
+    td_events: Events
+    top_left: [x: int, y: int]
+    size: [width, height]
+    """
+    valid_indices = (td_events.x >= top_left[0]) & (td_events.y >= top_left[1]) & (td_events.x < (size[0]+top_left[0])) & (td_events.y < (top_left[1]+size[1]))
     return  extract_indices(td_events, valid_indices.astype('bool'))
 
 
 def implement_refraction(td_events, us_time):
+    """Re-create the biological neuron behaviour where there is a refractory (enforced rest) period before a neuron can spike again
+    td_events: Events
+    us_time: time in microseconds
+    """
     max_x = max(td_events.x)
     max_y = max(td_events.y)
     T0 = np.ones((max_x+1,max_y+1))-us_time-1

--- a/example.py
+++ b/example.py
@@ -16,7 +16,7 @@ ev.show_td(TD)
 TD2 = ev.extract_roi(TD, [100,100], [50,50])
 
 #implement a refractory period... note this will also edit the event struct 'TD2'
-TD3 = ev.impement_refraction(TD2, 0.03)
+TD3 = ev.implement_refraction(TD2, 0.03)
 
 #perform some noise filtering... note this will also edit the event struct 'TD3'
 TD4 = ev.filter_td(TD3, 0.03)


### PR DESCRIPTION
Add optional parameter to show_td function for specifying the amount of time each image should be shown
Fix bugs in extract_roi function: top_left coordinate is now included and the size of the region to be extracted is applied correctly
